### PR TITLE
Update README fixing typo in charges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ foreach($list as $charge) {
 
 $pagination = $list->getPagination();
 ```
-### Get all changes
+### Get all charges
 ``` php
 $allCharges = Charge::getAll();
 ```


### PR DESCRIPTION
Just fixing a typo in the README.

Original: Get all changes
New: Get all charges