### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ You can find a simple example of how to use this with Express in the [`examples/
 use CoinbaseCommerce\Webhook;
 
 try {
-    Webhook::verifySignature($signature, $body, $sharedSecret);
+    Webhook::verifySignature($body, $signature, $sharedSecret);
     echo 'Successfully verified';
 } catch (\Exception $exception) {
     echo $exception->getMessage();


### PR DESCRIPTION
Webhook::verifySignature requires $body as the first parameter and $signature as second, whilst the documentation states it the other way around. This misunderstanding is now resolved.