### PR TITLE
Update ApiResource.php to match php@8.2

### DIFF
--- a/src/Resources/ApiResource.php
+++ b/src/Resources/ApiResource.php
@@ -4,6 +4,7 @@ namespace CoinbaseCommerce\Resources;
 use CoinbaseCommerce\ApiClient;
 use CoinbaseCommerce\ApiResponse;
 use CoinbaseCommerce\Util;
+use PhpOffice\PhpSpreadsheet\Worksheet\Iterator;
 
 class ApiResource extends \ArrayObject
 {
@@ -122,12 +123,12 @@ class ApiResource extends \ArrayObject
         return print_r($this->attributes, true);
     }
 
-    public static function setClient($client)
+    public static function setClient($client): void
     {
         self::$client = $client;
     }
 
-    protected static function getClient()
+    protected static function getClient(): mixed
     {
         if (self::$client) {
             return self::$client;
@@ -136,37 +137,37 @@ class ApiResource extends \ArrayObject
         return ApiClient::getInstance();
     }
 
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->__get($key);
     }
 
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         null === $key ? array_push($this->attributes, $value) : $this->attributes[$key] = $value;
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->attributes);
     }
 
-    public function asort()
+    public function asort(int $flags=SORT_REGULAR): bool
     {
         asort($this->attributes);
     }
 
-    public function ksort()
+    public function ksort(int $flags=SORT_REGULAR): bool
     {
         ksort($this->attributes);
     }
 
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->attributes[$key]);
     }
 
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         return new \ArrayIterator($this->attributes);
     }


### PR DESCRIPTION
Declaring return data types to ApiResource.php methods to match php@8.2

Resolves below compatibility issues:

`ErrorException: During inheritance of ArrayObject: Uncaught ErrorException: Return type of CoinbaseCommerce\Resources\ApiResource::getIterator(): mixed should either be compatible with ArrayObject::getIterator(): Iterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/coinbase/coinbase-commerce/src/Resources/ApiResource.php:169`

`ErrorException: Declaration of CoinbaseCommerce\Resources\ApiResource::ksort(): void must be compatible with ArrayObject::ksort(int $flags = SORT_REGULAR): bool in /vendor/coinbase/coinbase-commerce/src/Resources/ApiResource.php:159`

`ErrorException: During inheritance of ArrayObject: Uncaught yii\base\ErrorException: Return type of CoinbaseCommerce\Resources\ApiResource::count() should either be compatible with ArrayObject::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/coinbase/coinbase-commerce/src/Resources/ApiResource.php:149`

etc.